### PR TITLE
docs: update tools overview (README.md, AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,9 +14,19 @@ Source of truth: see `src/github_stars_contrib_mcp/tools/*` and `src/github_star
 
 ## Tools overview
 
+**Mutations:**
+- create_contribution
+  - input: { data: ContributionInput }
+  - output: { success: boolean, id?: string, error?: any }
 - create_contributions
   - input: { data: ContributionInput[] }
   - output: { success: boolean, ids?: string[], error?: any }
+- update_contributions
+  - input: { data: ContributionUpdateInput[] }
+  - output: { success: boolean, data?: object, error?: any }
+- delete_contributions
+  - input: { ids: string[] }
+  - output: { success: boolean, data?: object, error?: any }
 - create_link
   - input: { link: string, platform: string }
   - output: { success: boolean, data?: object, error?: any }
@@ -26,24 +36,29 @@ Source of truth: see `src/github_stars_contrib_mcp/tools/*` and `src/github_star
 - delete_link
   - input: { id: string }
   - output: { success: boolean, data?: object, error?: any }
-- update_contribution
-  - input: { id: string, data: ContributionUpdateInput }
+- update_profile
+  - input: { data: ProfileUpdateInput }
   - output: { success: boolean, data?: object, error?: any }
-- delete_contribution
-  - input: { id: string }
-  - output: { success: boolean, data?: object, error?: any }
-- get_user_data
-  - input: none
-  - output: { success: boolean, data?: object, error?: any }
+
+**Queries:**
 - get_user
   - input: none
   - output: { success: boolean, data?: object, error?: any }
 - get_stars
   - input: { username: string }
   - output: { success: boolean, data?: object, error?: any }
-- update_profile
-  - input: { data: ProfileUpdateInput }
+- search_contributions
+  - input: { username?: string, type?: string, title_contains?: string, date_from?: string, date_to?: string }
+  - output: { success: boolean, data?: object[], error?: any }
+- get_contributions_stats
+  - input: { username: string, group_by?: "type" | "month" | "year" | None }
   - output: { success: boolean, data?: object, error?: any }
+- compare_contributions
+  - input: { username1: string, username2: string, metric?: "total" | "by_type" | "by_year" | None }
+  - output: { success: boolean, data?: object, error?: any }
+- export_contributions
+  - input: { username: string, format?: "json" | "csv" | "markdown", sort_by?: "date" | "title" | "type" | None }
+  - output: { success: boolean, data?: string, error?: any }
 
 ContributionInput fields: title, url, description?, type, date (ISO)
 

--- a/README.md
+++ b/README.md
@@ -25,16 +25,23 @@ Environment variables:
 
 The server provides the following MCP tools:
 
+**Mutations (write operations):**
+- **create_contribution**: Create a single contribution
 - **create_contributions**: Create one or more contributions in a single mutation
-- **create_link**: Create a link in GitHub Stars profile
-- **delete_contributions**: Delete one or more contributions
-- **delete_link**: Delete a link from GitHub Stars profile
-- **get_stars**: Get the public profile stars/contributions for a GitHub user
-- **get_user_data**: Get the currently logged user's data (profile, nominee, contributions)
 - **update_contributions**: Update one or more contributions
+- **delete_contributions**: Delete one or more contributions
+- **create_link**: Create a link in GitHub Stars profile
 - **update_link**: Update a link in GitHub Stars profile
+- **delete_link**: Delete a link from GitHub Stars profile
 - **update_profile**: Update the user's profile information
-- **search_contributions**: Filter contributions from a user's public Stars profile (see `tools/search_contributions.py`)
+
+**Queries (read operations):**
+- **get_user**: Get the logged user (minimal user info without nominee data)
+- **get_stars**: Get the public profile stars/contributions for a GitHub user
+- **search_contributions**: Filter contributions from a user's public Stars profile
+- **get_contributions_stats**: Get contribution statistics and analytics (groupable by type, month, year)
+- **compare_contributions**: Compare contributions between two users
+- **export_contributions**: Export contributions in JSON, CSV, or Markdown format
 
 All tools return a standardized response format: `{ "success": boolean, "data": object | null, "error": string | null }`
 


### PR DESCRIPTION
This pull request updates the documentation for the GitHub Stars MCP tools to clarify and reorganize the available mutations and queries, reflecting the latest API changes and grouping operations more clearly. The changes improve consistency between `AGENTS.md` and `README.md`, and introduce new capabilities for contribution analytics and exporting.

**Tool organization and mutation/query updates:**

* Added new mutations for single contribution creation (`create_contribution`), bulk update and deletion (`update_contributions`, `delete_contributions`), and clarified input/output formats for each mutation in `AGENTS.md`.
* Removed deprecated single-item mutations (`update_contribution`, `delete_contribution`) and replaced them with batch operations for contributions, streamlining the API.
* Updated and reorganized the list of mutations and queries in `README.md` to match the latest API, improving clarity between write and read operations.

**New analytics and export features:**

* Introduced new queries for contribution statistics (`get_contributions_stats`), user comparison (`compare_contributions`), and exporting contributions in multiple formats (`export_contributions`) to both documentation files. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L29-R61) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R28-R44)

**General documentation improvements:**

* Improved grouping and descriptions of tool operations, and ensured standardized response formats are documented for all endpoints.